### PR TITLE
Suppress PHP "429 Too Many Requests" Warnings

### DIFF
--- a/src/Airbrake/Notifier.php
+++ b/src/Airbrake/Notifier.php
@@ -126,7 +126,7 @@ class Notifier
             ),
         );
         $context = stream_context_create($options);
-        $respData = file_get_contents($url, false, $context);
+        $respData = @file_get_contents($url, false, $context);
         if ($respData === false) {
             // TODO: handle this? how?
             return 0;


### PR DESCRIPTION
I think this warning happens when airbrake starts to rate limit. But depending on your error logging settings may create another error log for airbrake to handle.
