### PR TITLE
Check for file and line before assignment

### DIFF
--- a/src/Errors/Base.php
+++ b/src/Errors/Base.php
@@ -17,8 +17,12 @@ class Base
         $this->message = $message;
         $frame = array_shift($trace);
         if ($frame != null) {
-            $this->file = $frame['file'];
-            $this->line = $frame['line'];
+            if (isset($frame['file'])) {
+                $this->file = $frame['file'];    
+            }
+            if (isset($frame['line'])) {
+                $this->line = $frame['line'];    
+            }
         }
         $this->trace = $trace;
     }


### PR DESCRIPTION
If the file, line, or both are missing, this breaks completely.
