### PR TITLE
file_get_contents errors

### DIFF
--- a/src/Notifier.php
+++ b/src/Notifier.php
@@ -124,21 +124,32 @@ class Notifier
      */
     protected function postNotice($url, $data)
     {
-        $options = [
-            'http' => [
-                'header' => "Content-type: application/json\r\n",
-                'method' => 'POST',
-                'content' => $data,
-                'ignore_errors' => true,
-            ],
-        ];
-        $context = stream_context_create($options);
-        $respData = file_get_contents($url, false, $context);
-
-        return [
-            'headers' => $http_response_header,
-            'data' => $respData,
-        ];
+        try {
+            $respData = false;
+            $options = [
+                'http' => [
+                    'header' => "Content-type: application/json\r\n",
+                    'method' => 'POST',
+                    'content' => $data,
+                    'ignore_errors' => true,
+                ],
+            ];
+            $context = stream_context_create($options);
+            /* file_get_contents: https://secure.php.net/file_get_contents
+             *
+             * E_WARNING level error is generated if filename cannot be found,
+             * maxlength is less than zero,
+             * or if seeking to the specified offset in the stream fails. 
+            */
+            $respData = file_get_contents($url, false, $context);
+        } catch (Exception $e) {
+            throw $e;
+        } finally {
+            return [
+                'headers' => $http_response_header,
+                'data' => $respData,
+            ];
+        }
     }
 
     /**


### PR DESCRIPTION
Currently, we are seeing a number of errors because file_get_contents fails to open the URL.  

These errors should be handled in a way that they do not clutter the Airbrake.io dashboard of a project.

Additionally, I've set $respData to be initialized to false, so if the Exception is thrown, we still have the correct behavior.
