### PR TITLE
[#29] Add check if $http response header is set

### DIFF
--- a/src/Notifier.php
+++ b/src/Notifier.php
@@ -136,7 +136,7 @@ class Notifier
         $respData = file_get_contents($url, false, $context);
 
         return [
-            'headers' => $http_response_header,
+            'headers' => isset($http_response_header) ? $http_response_header : [],
             'data' => $respData,
         ];
     }


### PR DESCRIPTION
To be honest I'm confused why it wouldn't be set after the `file_get_contents` call in line 136 - maybe you have some idea, but I can confirm that this error is being reported on our production servers.
