### PR TITLE
Adds guzzle http client library

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,24 @@ $notifier = new Airbrake\Notifier([
 ]);
 ```
 
+### httpClient
+
+Configures the underlying http client. Expects "guzzle", "curl" or "default".
+- In order to use the "guzzle" client, the composer package "guzzlehttp/guzzle"
+must be installed.
+- Curl needs the curl php extension installed. See phpinfo().
+- The default client uses the php function "file_get_contents". Make sure
+"allow_url_fopen" is set to "1" in your php.ini.
+If not set the default client is used.
+
+```php
+$notifier = new Airbrake\Notifier([
+    // ...
+    'httpClient' => 'curl',
+    // ...
+]);
+```
+
 ## Running tests
 
 ```bash

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,7 @@
+dependencies:
+  pre:
+    - sed -i '/guzzle/d' composer.json
+
 machine:
   php:
     version: 5.4.37

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
     "require-dev": {
         "phpunit/phpunit": "^4.8.0",
         "squizlabs/php_codesniffer": "^2.5.1",
+        "guzzlehttp/guzzle": "^6.2",
         "monolog/monolog": "^1.16.0"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,8 @@
     "homepage": "https://airbrake.io",
     "license": "MIT",
     "require": {
-        "php": ">=5.4"
+        "php": ">=5.4",
+        "guzzlehttp/guzzle": "^6.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8.0",

--- a/composer.json
+++ b/composer.json
@@ -5,13 +5,15 @@
     "homepage": "https://airbrake.io",
     "license": "MIT",
     "require": {
-        "php": ">=5.4",
-        "guzzlehttp/guzzle": "^6.2"
+        "php": ">=5.4"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8.0",
         "squizlabs/php_codesniffer": "^2.5.1",
         "monolog/monolog": "^1.16.0"
+    },
+    "suggest": {
+        "guzzlehttp/guzzle": "Allows for implementation of the Guzzle HTTP client"
     },
     "autoload": {
         "psr-4": {

--- a/src/Http/ClientInterface.php
+++ b/src/Http/ClientInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Airbrake\Http;
+
+/**
+ * Interface ClientInterface
+ */
+interface ClientInterface
+{
+    /**
+     * Sends a request
+     *
+     * @param string $url  The endpoint to send the request to.
+     * @param string $data The body of the request as json encoded string
+     *
+     * @return array Raw response from the server.
+     *
+     * @throws \Airbrake\Exception
+     */
+    public function send($url, $data);
+}

--- a/src/Http/CurlClient.php
+++ b/src/Http/CurlClient.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Airbrake\Http;
+
+/**
+ * Class CurlClient
+ *
+ * @package Airbrake
+ */
+class CurlClient implements ClientInterface
+{
+    /**
+     * @inheritdoc
+     */
+    public function send($url, $data)
+    {
+        $curlOptions = [
+            CURLOPT_URL => $url,
+            CURLOPT_CUSTOMREQUEST => 'POST',
+            CURLOPT_POSTFIELDS => $data,
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_HEADER => true,
+            CURLOPT_HTTPHEADER => [
+                'Content-Type: application/json',
+                'Content-Length: ' . strlen($data),
+            ],
+        ];
+
+        $ch = curl_init();
+        curl_setopt_array($ch, $curlOptions);
+        $response = curl_exec($ch);
+
+        $headerSize = curl_getinfo($ch, CURLINFO_HEADER_SIZE);
+        $headers = trim(mb_substr($response, 0, $headerSize));
+        $body = trim(mb_substr($response, $headerSize));
+
+        curl_close($ch);
+        return ['headers' => $headers, 'data' => $body];
+    }
+}

--- a/src/Http/DefaultClient.php
+++ b/src/Http/DefaultClient.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Airbrake\Http;
+
+/**
+ * Class DefaultClient
+ *
+ * @package Airbrake
+ */
+class DefaultClient implements ClientInterface
+{
+    /**
+     * @inheritdoc
+     */
+    public function send($url, $data)
+    {
+        $options = [
+            'http' => [
+                'header' => "Content-type: application/json\r\n",
+                'method' => 'POST',
+                'content' => $data,
+                'ignore_errors' => true,
+            ],
+        ];
+        $context = stream_context_create($options);
+        $body = file_get_contents($url, false, $context);
+        $headers = (isset($http_response_header) ? $http_response_header : null);
+        return ['headers' => $headers, 'data' => $body];
+    }
+}

--- a/src/Http/Factory.php
+++ b/src/Http/Factory.php
@@ -19,10 +19,6 @@ class Factory
      */
     public static function createHttpClient($handler = null)
     {
-        if (!$handler) {
-            return self::detectDefaultClient();
-        }
-
         if ($handler === 'guzzle') {
             if (!class_exists('GuzzleHttp\Client')) {
                 throw new Exception('The Guzzle HTTP client must be included in order to use the "guzzle" handler.');
@@ -37,28 +33,10 @@ class Factory
             return new CurlClient();
         }
 
-        if ($handler === 'default') {
+        if (!$handler || $handler === 'default') {
             return new DefaultClient();
         }
 
         throw new InvalidArgumentException('The http client handler must be set to "default", "curl" or "guzzle"');
-    }
-
-    /**
-     * Detect default HTTP client.
-     *
-     * @return ClientInterface
-     */
-    private static function detectDefaultClient()
-    {
-        if (class_exists('GuzzleHttp\Client')) {
-            return new GuzzleClient();
-        }
-
-        if (extension_loaded('curl')) {
-            return new CurlClient();
-        }
-
-        return new DefaultClient();
     }
 }

--- a/src/Http/Factory.php
+++ b/src/Http/Factory.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Airbrake\Http;
+
+use Airbrake\Exception;
+use InvalidArgumentException;
+
+class Factory
+{
+    /**
+     * HTTP client generation.
+     *
+     * @param string|null $handler
+     *
+     * @throws Exception                If the cURL extension or the Guzzle client aren't available (if required).
+     * @throws InvalidArgumentException If the http client handler isn't "default", "curl" or "guzzle"
+     *
+     * @return ClientInterface
+     */
+    public static function createHttpClient($handler = null)
+    {
+        if (!$handler) {
+            return self::detectDefaultClient();
+        }
+
+        if ($handler === 'guzzle') {
+            if (!class_exists('GuzzleHttp\Client')) {
+                throw new Exception('The Guzzle HTTP client must be included in order to use the "guzzle" handler.');
+            }
+            return new GuzzleClient();
+        }
+
+        if ($handler === 'curl') {
+            if (!extension_loaded('curl')) {
+                throw new Exception('The cURL extension must be loaded in order to use the "curl" handler.');
+            }
+            return new CurlClient();
+        }
+
+        if ($handler === 'default') {
+            return new DefaultClient();
+        }
+
+        throw new InvalidArgumentException('The http client handler must be set to "default", "curl" or "guzzle"');
+    }
+
+    /**
+     * Detect default HTTP client.
+     *
+     * @return ClientInterface
+     */
+    private static function detectDefaultClient()
+    {
+        if (class_exists('GuzzleHttp\Client')) {
+            return new GuzzleClient();
+        }
+
+        if (extension_loaded('curl')) {
+            return new CurlClient();
+        }
+
+        return new DefaultClient();
+    }
+}

--- a/src/Http/GuzzleClient.php
+++ b/src/Http/GuzzleClient.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Airbrake\Http;
+
+use GuzzleHttp\Client;
+use Psr\Http\Message\ResponseInterface;
+
+class GuzzleClient implements ClientInterface
+{
+    /**
+     * @var \GuzzleHttp\Client The Guzzle client.
+     */
+    protected $guzzleClient;
+
+    /**
+     * @param \GuzzleHttp\Client|null The Guzzle client.
+     */
+    public function __construct(Client $guzzleClient = null)
+    {
+        $this->guzzleClient = $guzzleClient ?: new Client();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function send($url, $data)
+    {
+        $response = $this->guzzleClient->request('POST', $url, [
+            'headers' => [
+                'Content-type' => 'application/json',
+            ],
+            'body' => $data,
+        ]);
+
+        $headers = $this->getHeadersAsString($response);
+        $body = $response->getBody();
+
+        return ['headers' => $headers, 'data' => $body];
+    }
+
+    /**
+     * Returns the Guzzle array of headers as a string.
+     *
+     * @param ResponseInterface $response The Guzzle response.
+     *
+     * @return string
+     */
+    public function getHeadersAsString(ResponseInterface $response)
+    {
+        $headers = $response->getHeaders();
+        $rawHeaders = [];
+        foreach ($headers as $name => $values) {
+            $rawHeaders[] = $name . ": " . implode(", ", $values);
+        }
+
+        return implode("\r\n", $rawHeaders);
+    }
+}

--- a/src/Notifier.php
+++ b/src/Notifier.php
@@ -23,6 +23,12 @@ class Notifier
     private $filters = [];
 
     /**
+     * Http client
+     * @var Http\ClientInterface
+     */
+    private $client;
+
+    /**
      * Constructor
      *
      * Available options are:
@@ -32,6 +38,7 @@ class Notifier
      *  - appVersion
      *  - environment
      *  - rootDirectory
+     *  - httpClient    Autodetected or one of "default", "curl" or "guzzle"
      *
      * @param array $opt the options
      * @throws \Airbrake\Exception
@@ -51,6 +58,9 @@ class Notifier
                 return $this->rootDirectoryFilter($notice);
             });
         }
+
+        $handler = (isset($this->opt['httpClient']) ? $this->opt['httpClient'] : null);
+        $this->client = Http\Factory::createHttpClient($handler);
     }
 
     /**
@@ -78,10 +88,10 @@ class Notifier
         foreach ($trace as $frame) {
             $func = $frame['function'];
             if (isset($frame['class']) && isset($frame['type'])) {
-                $func = $frame['class'].$frame['type'].$func;
+                $func = $frame['class'] . $frame['type'] . $func;
             }
             if (count($backtrace) > 0) {
-                $backtrace[count($backtrace)-1]['function'] = $func;
+                $backtrace[count($backtrace) - 1]['function'] = $func;
             }
 
             $backtrace[] = [
@@ -113,7 +123,7 @@ class Notifier
                 'url' => 'https://github.com/airbrake/phpbrake',
             ],
             'os' => php_uname(),
-            'language' => 'php '.phpversion(),
+            'language' => 'php ' . phpversion(),
         ];
         if (!empty($this->opt['appVersion'])) {
             $context['version'] = $this->opt['appVersion'];
@@ -126,7 +136,7 @@ class Notifier
         }
         if (isset($_SERVER['HTTP_HOST']) && isset($_SERVER['REQUEST_URI'])) {
             $scheme = isset($_SERVER['HTTPS']) ? 'https' : 'http';
-            $context['url'] = $scheme.'://'.$_SERVER['HTTP_HOST'].$_SERVER['REQUEST_URI'];
+            $context['url'] = $scheme . '://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
         }
         if (isset($_SERVER['HTTP_USER_AGENT'])) {
             $context['userAgent'] = $_SERVER['HTTP_USER_AGENT'];
@@ -152,18 +162,7 @@ class Notifier
      */
     protected function postNotice($url, $data)
     {
-        $guzzle = new \GuzzleHttp\Client();
-        $response = $guzzle->request('POST', $url, [
-            'headers' => [
-                'Content-type' => 'application/json',
-            ],
-            'body' => $data,
-        ]);
-
-        return [
-            'headers' => $response->getHeaders(),
-            'data' => (string)$response->getBody(),
-        ];
+        return $this->client->send($url, $data);
     }
 
     /**

--- a/src/Notifier.php
+++ b/src/Notifier.php
@@ -38,7 +38,7 @@ class Notifier
      *  - appVersion
      *  - environment
      *  - rootDirectory
-     *  - httpClient    Autodetected or one of "default", "curl" or "guzzle"
+     *  - httpClient    which http client to use: "default", "curl" or "guzzle"
      *
      * @param array $opt the options
      * @throws \Airbrake\Exception

--- a/src/Notifier.php
+++ b/src/Notifier.php
@@ -152,20 +152,17 @@ class Notifier
      */
     protected function postNotice($url, $data)
     {
-        $options = [
-            'http' => [
-                'header' => "Content-type: application/json\r\n",
-                'method' => 'POST',
-                'content' => $data,
-                'ignore_errors' => true,
+        $guzzle = new \GuzzleHttp\Client();
+        $response = $guzzle->request('POST', $url, [
+            'headers' => [
+                'Content-type' => 'application/json',
             ],
-        ];
-        $context = stream_context_create($options);
-        $respData = file_get_contents($url, false, $context);
+            'body' => $data,
+        ]);
 
         return [
-            'headers' => isset($http_response_header) ? $http_response_header : [],
-            'data' => $respData,
+            'headers' => $response->getHeaders(),
+            'data' => (string)$response->getBody(),
         ];
     }
 

--- a/tests/HttpFactoryTest.php
+++ b/tests/HttpFactoryTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Airbrake\Tests;
+
+use PHPUnit_Framework_TestCase;
+
+class HttpFactoryTest extends PHPUnit_Framework_TestCase
+{
+    public function testGuzzleClient()
+    {
+        if (!class_exists('GuzzleHttp\Client')) {
+            $this->markTestSkipped('Guzzle client is not available.');
+        }
+        
+        $client = \Airbrake\Http\Factory::createHttpClient('guzzle');
+        $this->assertInstanceOf('\Airbrake\Http\GuzzleClient', $client);
+    }
+
+    public function testCurlClient()
+    {
+        $client = \Airbrake\Http\Factory::createHttpClient('curl');
+        $this->assertInstanceOf('\Airbrake\Http\CurlClient', $client);
+    }
+
+    public function testDefaultClient()
+    {
+        $client = \Airbrake\Http\Factory::createHttpClient('default');
+        $this->assertInstanceOf('\Airbrake\Http\DefaultClient', $client);
+
+        $client = \Airbrake\Http\Factory::createHttpClient();
+        $this->assertInstanceOf('\Airbrake\Http\DefaultClient', $client);
+    }
+
+    public function testUndefineClient()
+    {
+        $this->setExpectedException('InvalidArgumentException');
+        $client = \Airbrake\Http\Factory::createHttpClient('undefined client');
+    }
+}


### PR DESCRIPTION
Sends notifications using guzzle post requests

Because of strict php.ini settings (allow_url_fopen=0) we cannot use file_get_contents to send out airbrake notifications. So i replaced it with the guzzle library.
