### PR TITLE
Bump phpbrake Notifier version

### DIFF
--- a/src/Notifier.php
+++ b/src/Notifier.php
@@ -109,7 +109,7 @@ class Notifier
         $context = [
             'notifier' => [
                 'name' => 'phpbrake',
-                'version' => '0.0.5',
+                'version' => '0.1.1',
                 'url' => 'https://github.com/airbrake/phpbrake',
             ],
             'os' => php_uname(),


### PR DESCRIPTION
**Summary**
Fix error notice in emails from Airbrake as we're reporting an incorrect version of phpbrake in `Notifier.php`

**Example Error**
![screen shot 2016-06-14 at 16 10 54](https://cloud.githubusercontent.com/assets/1690006/16048139/cf0e9000-324a-11e6-802d-0a676d2d2803.png)
