### PR TITLE
Fix an order of operations error in the onShutdown() handler

### DIFF
--- a/src/ErrorHandler.php
+++ b/src/ErrorHandler.php
@@ -66,7 +66,7 @@ class ErrorHandler
         if ($error === null) {
             return;
         }
-        if ($error['type'] & error_reporting() === 0) {
+        if (($error['type'] & error_reporting()) === 0) {
             return;
         }
         $exc = new Errors\Fatal($error['message'], debug_backtrace());


### PR DESCRIPTION
The `onShutdown()` handler attempts to skip errors that don't match the current error reporting level. Unfortunately, PHP is quirky and gives comparison operators (e.g. `===`) a higher precedence than bit-wise operators (e.g. `&`).

This can lead to the following unexpected behavior: Suppose your error reporting level is set to `E_ALL & ~E_NOTICE` (i.e. everything except notices) and your application triggers an `E_NOTICE`. This notice will **not** be reported by `onError()`, as expected, but it **will** be reported by `onShutdown()`, due to the issue mentioned above. As a result, that `E_NOTICE` will show up in Airbrake as an `Airbrake\Errors\Fatal`!