### PR TITLE
vendor path

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ vendor/bin/phpunit
 ## PHPDoc
 ```bash
 composer require phpdocumentor/phpdocumentor
-bin/phpdoc -d src
+vendor/bin/phpdoc -d src
 firefox output/index.html
 ```
 


### PR DESCRIPTION
As for running tests it's needed the vendor path prefix, or as an alternative way it can be configured the "config" param on the composer file.
```
"config": {
        "bin-dir": "./bin"
    }
```