### PR TITLE
Release v0.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,15 @@ Phpbrake Changelog
 
 ### master
 
+### [v0.2.4][v0.2.4] (May 11, 2017)
+
+* Started sending customizable severity option (defaults to `error`)
+  ([#55](https://github.com/airbrake/phpbrake/pull/55))
+
 ### [v0.2.0][v0.2.0] (July 21, 2016)
 
 * Introduced new option: `httpClient`
   ([#38](https://github.com/airbrake/phpbrake/pull/38))
 
 [v0.2.0]: https://github.com/airbrake/phpbrake/releases/tag/v0.2.0
+[v0.2.4]: https://github.com/airbrake/phpbrake/releases/tag/v0.2.4

--- a/src/Notifier.php
+++ b/src/Notifier.php
@@ -119,7 +119,7 @@ class Notifier
         $context = [
             'notifier' => [
                 'name' => 'phpbrake',
-                'version' => '0.2.2',
+                'version' => '0.2.4',
                 'url' => 'https://github.com/airbrake/phpbrake',
             ],
             'os' => php_uname(),


### PR DESCRIPTION
Bumping from v0.2.2 to v0.2.4 because we have pushed the v0.2.3 tag, but
apparently forgot to increment notifier version:
https://github.com/airbrake/phpbrake/releases/tag/v0.2.3