### PR TITLE
Custom HTTP clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,18 +183,33 @@ $notifier = new Airbrake\Notifier([
 
 ### httpClient
 
-Configures the underlying http client. Expects "guzzle", "curl" or "default".
+Configures the underlying http client. Expects "guzzle", "curl", "default", or
+an instantiated client. If not set the default client is used.
 - In order to use the "guzzle" client, the composer package "guzzlehttp/guzzle"
 must be installed.
 - Curl needs the curl php extension installed. See phpinfo().
 - The default client uses the php function "file_get_contents". Make sure
 "allow_url_fopen" is set to "1" in your php.ini.
-If not set the default client is used.
+- To provide your own client, instantiate and configure one of the clients in
+`Airbrake\Http`.
 
 ```php
+// Use the Curl client.
 $notifier = new Airbrake\Notifier([
     // ...
     'httpClient' => 'curl',
+    // ...
+]);
+```
+```php
+// Supply your own client.
+$client = new Airbrake\Http\GuzzleClient(
+    new GuzzleHttp\Client(['timeout' => 3])
+);
+
+$notifier = new Airbrake\Notifier([
+    // ...
+    'httpClient' => $client,
     // ...
 ]);
 ```

--- a/src/Notifier.php
+++ b/src/Notifier.php
@@ -38,7 +38,8 @@ class Notifier
      *  - appVersion
      *  - environment
      *  - rootDirectory
-     *  - httpClient    which http client to use: "default", "curl" or "guzzle"
+     *  - httpClient    which http client to use: "default", "curl", "guzzle" or a client instance
+     *                  implementing Http\ClientInterface
      *
      * @param array $opt the options
      * @throws \Airbrake\Exception
@@ -51,6 +52,7 @@ class Notifier
 
         $this->opt = array_merge([
             'host' => 'api.airbrake.io',
+            'httpClient' => null,
         ], $opt);
 
         if (!empty($opt['rootDirectory'])) {
@@ -59,8 +61,9 @@ class Notifier
             });
         }
 
-        $handler = (isset($this->opt['httpClient']) ? $this->opt['httpClient'] : null);
-        $this->client = Http\Factory::createHttpClient($handler);
+        $this->client = $this->opt['httpClient'] instanceof Http\ClientInterface
+            ? $this->opt['httpClient']
+            : Http\Factory::createHttpClient($this->opt['httpClient']);
     }
 
     /**


### PR DESCRIPTION
See #57 for previous implementation discussion

- [x] @ethanpooley to do additional live testing before merging (I live-tested the last implementation before PRing, but this one I figured we could discuss first)

Thank you @vmihailenco, this is much cleaner. `Airbrake\Http\GuzzleClient` isn't set up to take options today, but it does take an entire client. So I left it at that. The usage example would be:
```php
$client = new Airbrake\Http\GuzzleClient(
    new GuzzleHttp\Client(...options here...)
);

$notifier = new Airbrake\Notifier([
    'httpClient' => $client,
]);
```
Side note: the last time I built an API client I used the HTTPlug interface from the [PHP-HTTP project](http://docs.php-http.org/en/latest/). phpbrake could do that and get rid of its own interface and implementations entirely. The project even includes a [socket-based client](http://docs.php-http.org/en/latest/clients/socket-client.html) that could replace phpbrake's `file_get_contents()` default client. That [should be more compatible](http://henryranch.net/2009/the-crippling-of-phps-file_get_contents/) and wouldn't require the [installation note](https://github.com/airbrake/phpbrake#httpclient) about php.ini settings. If you're interested I will give this a go.