### PR TITLE
Set a default message when an Exception/Throwable does not have one.

### DIFF
--- a/src/Notifier.php
+++ b/src/Notifier.php
@@ -153,6 +153,10 @@ class Notifier
             'backtrace' => $this->backtrace($exc)
         ];
 
+        if (empty($error['message'])) {
+            $error['message'] = 'empty';
+        }
+
         $context = [
             'notifier' => [
                 'name' => 'phpbrake',


### PR DESCRIPTION
All predefined Exception/Throwable implementations default to and allow
empty messages, but api.airbrake.io does not support this. If a message
is empty, set a default value.