### PR TITLE
fix: http client type check in notifier

### DIFF
--- a/src/Notifier.php
+++ b/src/Notifier.php
@@ -146,7 +146,7 @@ class Notifier
     private function newHTTPClient()
     {
         if (array_key_exists('httpClient', $this->opt)) {
-            if ($this->opt['httpClient'] instanceof GuzzleHttp\ClientInterface) {
+            if ($this->opt['httpClient'] instanceof \GuzzleHttp\ClientInterface) {
                 return $this->opt['httpClient'];
             }
             throw new Exception('phpbrake: httpClient must implement GuzzleHttp\ClientInterface');


### PR DESCRIPTION
This type check fails because it lacks the root namespace identifier, so the check is actually for `Airbrake\GuzzleHttp\ClientInterface`