### PR TITLE
Prevent loading PHP modules that look like files

### DIFF
--- a/src/CodeHunk.php
+++ b/src/CodeHunk.php
@@ -28,6 +28,10 @@ class CodeHunk
 
     private function _get($file, $line)
     {
+        if (!file_exists($file)) {
+            return null;
+        }
+
         $fh = fopen($file, 'r');
         if (!$fh) {
             return null;

--- a/tests/FakeTraceException.php
+++ b/tests/FakeTraceException.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Airbrake\Tests;
+
+/**
+ * We opt for composition and magic method proxying of Exceptions instead of
+ * simply extending \Exception because getTrace() is marked as final.
+ */
+class FakeTraceException
+{
+    protected $exc;
+    protected $traceOverrides;
+
+    public function __construct()
+    {
+        $this->exc = new \Exception('wrapped exception', 1);
+        $this->traceOverrides = [];
+    }
+
+    public function getTrace()
+    {
+        return $this->traceOverrides + $this->exc->getTrace();
+    }
+
+    public function addFakeTrace($position, $frame)
+    {
+        $this->traceOverrides[$position] = $frame;
+    }
+
+    public function __call($name, $args)
+    {
+        return call_user_func_array([$this->exc, $name], $args);
+    }
+
+    public function __get($name)
+    {
+        return $this->exc->$name;
+    }
+}

--- a/tests/NotifierTest.php
+++ b/tests/NotifierTest.php
@@ -232,4 +232,23 @@ class NotifierTest extends PHPUnit_Framework_TestCase
         );
         $this->assertEquals($err['backtrace'][0]['line'], 19);
     }
+
+    public function testPhpModulesAreSkipped()
+    {
+        $notifier = $this->newNotifier();
+        $exc = new FakeTraceException();
+        $exc->addFakeTrace(2, [
+            'file' => 'newrelic/Guzzle6',
+            'line' => 1,
+            'function' => 'GuzzleHttp\Handler\{closure}',
+            'class' => 'GuzzleHttp\Handler\Proxy',
+            'args' => [],
+        ]);
+        $notifier->notify($exc);
+
+        $this->assertEquals(
+            $notifier->notice['errors'][0]['backtrace'][1]['file'],
+            'newrelic/Guzzle6'
+        );
+    }
 }


### PR DESCRIPTION
Occasionally the stack trace contains a frame that points to a `file` that isn't one.

A great example can be found here: https://laracasts.com/discuss/channels/laravel/random-curl-error-77-mail-mandrill-driver-aws-sqs
Look at frames 4-6 in the stacktrace above, namely 5. It shows:

```
#4 /var/app/current/vendor/guzzlehttp/guzzle/src/Handler/Proxy.php(51): GuzzleHttp\Handler\Proxy::GuzzleHttp\Handler\{closure}(Object(GuzzleHttp\Psr7\Request), Array)
#5 newrelic/Guzzle6(1): GuzzleHttp\Handler\Proxy::GuzzleHttp\Handler\{closure}(Object(GuzzleHttp\Psr7\Request), Array)
#6 /var/app/current/vendor/guzzlehttp/guzzle/src/PrepareBodyMiddleware.php(72): newrelic\Guzzle6\{closure}(Object(GuzzleHttp\Psr7\Request), Array)
```

Notice that `PrepareBodyMiddleware.php` calls out to PHP function `newrelic\Guzzle6\{closure}`. In the next frame, that frame is actually shaped something like this:

```php
[
    'file' => 'newrelic/Guzzle6',
    'line' => 1,
    'function' => 'GuzzleHttp\Handler\{closure}',
    'class' => 'GuzzleHttp\Handler\Proxy',
    'args' => [],
]
```

Because the key `file` exists in this frame, `phpbrake` attempts to open it. This ends up throwing another exception in the exception handler itself.