### PR TITLE
Replace blacklist keys with blocklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,12 +234,12 @@ $notifier = new Airbrake\Notifier([
 
 ### Filtering keys
 
-With `keysBlacklist` option you can specify list of keys containing sensitive information that must be filtered out, e.g.:
+With `keysBlocklist` option you can specify list of keys containing sensitive information that must be filtered out, e.g.:
 
 ```php
 $notifier = new Airbrake\Notifier([
     // ...
-    'keysBlacklist' => ['/secret/i', '/password/i'],
+    'keysBlocklist' => ['/secret/i', '/password/i'],
     // ...
 ]);
 ```
@@ -265,7 +265,7 @@ In case you have a problem, question or a bug report, feel free to:
 
 * [file an issue](https://github.com/airbrake/phpbrake/issues)
 * [send us an email](mailto:support@airbrake.io)
-  
+
 ## License
 
 PHPBrake is licensed under [The MIT License (MIT)](LICENSE).

--- a/src/Notifier.php
+++ b/src/Notifier.php
@@ -59,7 +59,7 @@ class Notifier
      *  - environment
      *  - revision      git revision
      *  - rootDirectory
-     *  - keysBlacklist list of keys containing sensitive information that must be filtered out
+     *  - keysBlocklist list of keys containing sensitive information that must be filtered out
      *  - httpClient    http client implementing GuzzleHttp\ClientInterface
      *
      * @param array $opt the options
@@ -71,21 +71,29 @@ class Notifier
             throw new Exception('phpbrake: Notifier requires projectId and projectKey');
         }
 
+        if (isset($opt['keysBlacklist'])) {
+            error_log(
+                'phpbrake: keysBlacklist is a deprecated option. Use keysBlocklist instead.'
+            );
+            $opt['keysBlocklist'] = $opt['keysBlacklist'];
+        }
+
         $this->opt = array_merge([
           'host' => 'api.airbrake.io',
-          'keysBlacklist' => ['/password/i', '/secret/i'],
+          'keysBlocklist' => ['/password/i', '/secret/i'],
         ], $opt);
+
         $this->httpClient = $this->newHTTPClient();
         $this->noticesURL = $this->buildNoticesURL();
         $this->codeHunk = new CodeHunk();
         $this->context = $this->buildContext();
 
-        if (array_key_exists('keysBlacklist', $this->opt)) {
+        if (array_key_exists('keysBlocklist', $this->opt)) {
             $this->addFilter(function ($notice) {
                 $noticeKeys = array('context', 'params', 'session', 'environment');
                 foreach ($noticeKeys as $key) {
                     if (array_key_exists($key, $notice)) {
-                        $this->filterKeys($notice[$key], $this->opt['keysBlacklist']);
+                        $this->filterKeys($notice[$key], $this->opt['keysBlocklist']);
                     }
                 }
                 return $notice;
@@ -520,16 +528,16 @@ class Notifier
         return null;
     }
 
-    private function filterKeys(array &$arr, array $keysBlacklist)
+    private function filterKeys(array &$arr, array $keysBlocklist)
     {
         foreach ($arr as $k => $v) {
-            foreach ($keysBlacklist as $regexp) {
+            foreach ($keysBlocklist as $regexp) {
                 if (preg_match($regexp, $k)) {
                     $arr[$k] = '[Filtered]';
                     continue;
                 }
                 if (is_array($v)) {
-                    $this->filterKeys($arr[$k], $keysBlacklist);
+                    $this->filterKeys($arr[$k], $keysBlocklist);
                 }
             }
         }


### PR DESCRIPTION
Closes: https://github.com/airbrake/phpbrake/issues/103

Deprecate "blacklist" terminology in favor of "blocklist" for filtering keys. The old "keysBlacklist" is still used if users have it set but it is switched out for "keysBlocklist" in the README.

Filtering keys: https://github.com/airbrake/phpbrake#filtering-keys