### PR TITLE
Suppress notification if error_reporting() has narrowed

### DIFF
--- a/src/ErrorHandler.php
+++ b/src/ErrorHandler.php
@@ -31,6 +31,13 @@ class ErrorHandler
      */
     public function onError($code, $message, $file, $line)
     {
+        // If error_reporting() setting has changed since the ErrorHandler was
+        // installed, respect the new settings. This also respects the
+        // @-operator (issue #105)
+        if ((error_reporting() & $code) === 0) {
+            return false;
+        }
+
         $this->lastError = [
             'message' => $message,
             'file' => $file,

--- a/tests/ErrorHandlerTest.php
+++ b/tests/ErrorHandlerTest.php
@@ -33,6 +33,19 @@ class ErrorHandlerTest extends PHPUnit_Framework_TestCase
         ];
     }
 
+    public function testSuppression()
+    {
+        list($notifier, $handler) = $this->makeHandlerBoundNotifier();
+
+        // Cause two errors in a row, but suppress the second one. Verify that
+        // the notifier's most recent notice corresponds to the first error
+        // generated.
+        Troublemaker::echoUndefinedVar();
+        @Troublemaker::echoUndefinedIndex();
+
+        $this->testPostsError($notifier);
+    }
+
     private function makeHandlerBoundNotifier()
     {
         $notifier = new NotifierMock([
@@ -58,7 +71,7 @@ class ErrorHandlerTest extends PHPUnit_Framework_TestCase
     private function arrangeOnShutdownNotifier()
     {
         list($notifier, $handler) = $this->makeHandlerBoundNotifier();
-        @Troublemaker::echoUndefinedVar();
+        Troublemaker::echoUndefinedVar();
         $handler->onShutdown();
 
         return $notifier;

--- a/tests/Troublemaker.php
+++ b/tests/Troublemaker.php
@@ -42,4 +42,15 @@ class Troublemaker
             return new \Exception('world', 207, $e);
         }
     }
+
+    private static function doEchoUndefinedIndex()
+    {
+        $foo = [];
+        echo $foo[0];
+    }
+
+    public static function echoUndefinedIndex()
+    {
+        self::doEchoUndefinedIndex();
+    }
 }


### PR DESCRIPTION
If the error_reporting() setting has narrowed since Airbrake's error
handler was installed, respect the new setting. This also resolves the
issue of errors suppressed with the "@" operator being reported to
Airbrake. (Fixes #105)