### PR TITLE
Add supported PHP version to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 
 ## Features
 PHPBrake is the official [Airbrake](https://airbrake.io) PHP error notifier.
-PHPBrake includes many useful features that give you control over when and
-what you send to Airbrake, you can:
+PHPBrake supports PHP 5.4 and higher. PHPBrake includes many useful features 
+that give you control over when and what you send to Airbrake, you can:
 
 - [Send notices from try-catch blocks in your code](https://github.com/airbrake/phpbrake#quickstart)
 - [Add custom data to a notice](https://github.com/airbrake/phpbrake#adding-custom-data-to-the-notice)


### PR DESCRIPTION
Add mention of supported PHP versions to the readme. Based on:
https://github.com/airbrake/phpbrake/blob/master/composer.json#L14

## Addition

<img width="768" alt="Screen Shot 2021-02-16 at 9 08 49 AM" src="https://user-images.githubusercontent.com/2172513/108097151-9ed16500-7036-11eb-8f4e-62e174b5f16c.png">
