### PR TITLE
Fetch the remote notifier config

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## Features
 PHPBrake is the official [Airbrake](https://airbrake.io) PHP error notifier.
-PHPBrake supports PHP 5.4 and higher. PHPBrake includes many useful features 
+PHPBrake supports PHP 5.4 and higher. PHPBrake includes many useful features
 that give you control over when and what you send to Airbrake, you can:
 
 - [Send notices from try-catch blocks in your code](https://github.com/airbrake/phpbrake#quickstart)
@@ -187,6 +187,26 @@ $notifier = new Airbrake\Notifier([
     // ...
 ]);
 ```
+
+### remoteConfig
+
+Configures the remote configuration feature. Every 10 minutes the notifier
+will make a GET request to Airbrake servers to fetching a JSON document
+containing configuration settings for your project. The notifier will apply
+these new settings at runtime. By default, it is enabled.
+
+To disable this feature, configure your notifier with:
+
+```php
+$notifier = new Airbrake\Notifier([
+    // ...
+    'remoteConfig' => false,
+    // ...
+]);
+```
+
+Note: it is not recommended to disable this feature. It might negatively impact
+how your notifier works. Please use this option with caution.
 
 ### rootDirectory
 

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
   "require-dev": {
     "phpunit/phpunit": "^5.7",
     "squizlabs/php_codesniffer": "^2.9",
-    "monolog/monolog": "^1.22|^2.0"
+    "monolog/monolog": "^1.22|^2.0",
+    "mikey179/vfsstream": "^1.6"
   },
   "suggest": {
     "guzzlehttp/guzzle": "Guzzle HTTP client"

--- a/src/Notifier.php
+++ b/src/Notifier.php
@@ -564,6 +564,10 @@ class Notifier
             return RemoteConfig::DEFAULT_CONFIG;
         }
 
+        if (isset($this->errorConfig)) {
+            return $this->errorConfig;
+        }
+
         $remoteConfig = $this->newRemoteConfig($this->opt['projectId']);
         $this->errorConfig = $remoteConfig->errorConfig();
         return $this->errorConfig;

--- a/src/Notifier.php
+++ b/src/Notifier.php
@@ -22,11 +22,6 @@ class Notifier
     private static $instanceCount = 0;
 
     /**
-     * @var string
-     */
-    protected $noticesURL;
-
-    /**
      * @var array
      */
     protected $opt;
@@ -91,7 +86,6 @@ class Notifier
         );
 
         $this->httpClient = $this->newHTTPClient();
-        $this->noticesURL = $this->buildNoticesURL();
         $this->codeHunk = new CodeHunk();
         $this->context = $this->buildContext();
 
@@ -349,8 +343,12 @@ class Notifier
             'Authorization' => 'Bearer ' . $this->opt['projectKey'],
         ];
         $body = json_encode($notice);
-        $this->noticesURL = $this->buildNoticesURL();
-        return new \GuzzleHttp\Psr7\Request('POST', $this->noticesURL, $headers, $body);
+        return new \GuzzleHttp\Psr7\Request(
+            'POST',
+            $this->buildNoticesURL(),
+            $headers,
+            $body
+        );
     }
 
     protected function sendRequest($req)

--- a/src/Notifier.php
+++ b/src/Notifier.php
@@ -573,8 +573,7 @@ class Notifier
 
     protected function newRemoteConfig($projectId)
     {
-        $remoteConfig = new RemoteConfig($projectId);
-        return $remoteConfig;
+        return new RemoteConfig($projectId);
     }
 
     private function filterKeys(array &$arr, array $keysBlocklist)

--- a/src/Notifier.php
+++ b/src/Notifier.php
@@ -562,7 +562,7 @@ class Notifier
 
     protected function remoteErrorConfig()
     {
-        if ($this->opt['remoteConfig'] == false) {
+        if (!$this->opt['remoteConfig']) {
             return RemoteConfig::DEFAULT_CONFIG;
         }
 

--- a/src/RemoteConfig.php
+++ b/src/RemoteConfig.php
@@ -96,6 +96,7 @@ class RemoteConfig
         foreach ($config['settings'] as $cfg) {
             if (isset($cfg["name"]) && $cfg["name"] == "errors") {
                 $errorConfig = $cfg;
+                break;
             }
         };
 

--- a/src/RemoteConfig.php
+++ b/src/RemoteConfig.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace Airbrake;
+
+use GuzzleHttp\Client;
+
+class RemoteConfig
+{
+    protected $remoteConfigURL;
+    protected $httpClient;
+    protected $tempCache;
+    protected $tempCacheFilename = 'airbrake_cached_remote_config.json';
+    protected $tempCacheTTL = 600;
+    private $defaultConfig = [
+        "host" => 'api.airbrake.io',
+        "enabled" => true
+    ];
+    private $remoteConfigURLFormatString = 'https://notifier-configs.airbrake.io' .
+        '/2020-06-18/config/%d/config.json';
+    private $notifierInfo = [
+        'notifier_name' => 'phpbrake',
+        'notifier_version' => AIRBRAKE_NOTIFIER_VERSION,
+        'os' => PHP_OS,
+        'language' => "PHP" . PHP_VERSION
+    ];
+
+    public function __construct($projectId)
+    {
+        $this->remoteConfigURL = $this->buildRemoteUrl($projectId);
+        $this->httpClient = $this->newHTTPClient();
+        $this->tempCache = $this->newTempCache();
+    }
+
+    public function errorConfig()
+    {
+        $config = $this->getConfigFromCacheOrFetch();
+        return $this->parseErrorConfig($config);
+    }
+
+    private function getConfigFromCacheOrFetch()
+    {
+        try {
+            if ($this->tempCache->canWrite() == false) {
+                return $this->defaultConfig;
+            }
+
+            if ($this->tempCache->expired()) {
+                $config = $this->fetchConfig();
+                $this->tempCache->write($config);
+            } else {
+                $config = $this->tempCache->read();
+            }
+        } catch (\Exception $e) {
+            unset($e); // $e is not used.
+            return $this->defaultConfig;
+        }
+
+        return $config;
+    }
+
+    /**
+      The fetchConfig method returns the remote error config from s3 when
+      everything goes right and returns the default config when there is an
+      issue.
+    **/
+    private function fetchConfig()
+    {
+        try {
+            $response = $this->httpClient->request(
+                'GET',
+                $this->remoteConfigURL,
+                ['query' => $this->notifierInfo]
+            );
+        } catch (\Exception $e) {
+            unset($e); // $e is not used.
+            return $this->defaultConfig;
+        }
+
+        if ($response->getStatusCode() != 200) {
+            return $this->defaultConfig;
+        }
+
+        $body = $response->getBody();
+        $config = json_decode($body, true);
+
+        return $config;
+    }
+
+    private function parseErrorConfig($config)
+    {
+        $config_not_found = array_key_exists("settings", (array) $config) == false;
+        if ($config_not_found) {
+            return $this->defaultConfig;
+        }
+
+        foreach ($config['settings'] as $cfg) {
+            if (isset($cfg["name"]) && $cfg["name"] == "errors") {
+                $errorConfig = $cfg;
+            }
+        };
+
+        if (isset($errorConfig['endpoint'])) {
+            $host = $errorConfig['endpoint'];
+        } else {
+            $host = $this->defaultConfig['host'];
+        }
+
+        if (isset($errorConfig['enabled'])) {
+            $enabled = $errorConfig['enabled'];
+        } else {
+            $enabled = $this->defaultConfig['enabled'];
+        }
+
+        return array("host" => $host, "enabled" => $enabled);
+    }
+
+    private function buildRemoteUrl($projectId)
+    {
+        return sprintf(
+            $this->remoteConfigURLFormatString,
+            $projectId
+        );
+    }
+
+    private function newHTTPClient()
+    {
+        return new Client(
+            [
+                'connect_timeout' => 2,
+                'read_timeout' => 2,
+                'timeout' => 2,
+            ]
+        );
+    }
+
+    protected function newTempCache()
+    {
+        return new TempCache(
+            $this->tempCacheFilename,
+            $this->tempCacheTTL
+        );
+    }
+}

--- a/src/RemoteConfig.php
+++ b/src/RemoteConfig.php
@@ -40,7 +40,7 @@ class RemoteConfig
     private function getConfigFromCacheOrFetch()
     {
         try {
-            if ($this->tempCache->canWrite() == false) {
+            if (!$this->tempCache->canWrite()) {
                 return self::DEFAULT_CONFIG;
             }
 

--- a/src/RemoteConfig.php
+++ b/src/RemoteConfig.php
@@ -127,9 +127,9 @@ class RemoteConfig
     {
         return new Client(
             [
-                'connect_timeout' => 2,
-                'read_timeout' => 2,
-                'timeout' => 2,
+                'connect_timeout' => 10,
+                'read_timeout' => 10,
+                'timeout' => 10,
             ]
         );
     }

--- a/src/RemoteConfig.php
+++ b/src/RemoteConfig.php
@@ -6,15 +6,15 @@ use GuzzleHttp\Client;
 
 class RemoteConfig
 {
+    const DEFAULT_CONFIG = [
+        "host" => 'api.airbrake.io',
+        "enabled" => true
+    ];
     protected $remoteConfigURL;
     protected $httpClient;
     protected $tempCache;
     protected $tempCacheFilename = 'airbrake_cached_remote_config.json';
     protected $tempCacheTTL = 600;
-    private $defaultConfig = [
-        "host" => 'api.airbrake.io',
-        "enabled" => true
-    ];
     private $remoteConfigURLFormatString = 'https://notifier-configs.airbrake.io' .
         '/2020-06-18/config/%d/config.json';
     private $notifierInfo = [
@@ -41,7 +41,7 @@ class RemoteConfig
     {
         try {
             if ($this->tempCache->canWrite() == false) {
-                return $this->defaultConfig;
+                return self::DEFAULT_CONFIG;
             }
 
             if ($this->tempCache->expired()) {
@@ -52,7 +52,7 @@ class RemoteConfig
             }
         } catch (\Exception $e) {
             unset($e); // $e is not used.
-            return $this->defaultConfig;
+            return self::DEFAULT_CONFIG;
         }
 
         return $config;
@@ -73,11 +73,11 @@ class RemoteConfig
             );
         } catch (\Exception $e) {
             unset($e); // $e is not used.
-            return $this->defaultConfig;
+            return self::DEFAULT_CONFIG;
         }
 
         if ($response->getStatusCode() != 200) {
-            return $this->defaultConfig;
+            return self::DEFAULT_CONFIG;
         }
 
         $body = $response->getBody();
@@ -90,7 +90,7 @@ class RemoteConfig
     {
         $config_not_found = array_key_exists("settings", (array) $config) == false;
         if ($config_not_found) {
-            return $this->defaultConfig;
+            return self::DEFAULT_CONFIG;
         }
 
         foreach ($config['settings'] as $cfg) {
@@ -102,13 +102,13 @@ class RemoteConfig
         if (isset($errorConfig['endpoint'])) {
             $host = $errorConfig['endpoint'];
         } else {
-            $host = $this->defaultConfig['host'];
+            $host = self::DEFAULT_CONFIG['host'];
         }
 
         if (isset($errorConfig['enabled'])) {
             $enabled = $errorConfig['enabled'];
         } else {
-            $enabled = $this->defaultConfig['enabled'];
+            $enabled = self::DEFAULT_CONFIG['enabled'];
         }
 
         return array("host" => $host, "enabled" => $enabled);

--- a/src/RemoteConfig.php
+++ b/src/RemoteConfig.php
@@ -88,8 +88,8 @@ class RemoteConfig
 
     private function parseErrorConfig($config)
     {
-        $config_not_found = array_key_exists("settings", (array) $config) == false;
-        if ($config_not_found) {
+        $config_found = array_key_exists("settings", (array) $config);
+        if (!$config_found) {
             return self::DEFAULT_CONFIG;
         }
 

--- a/src/RemoteConfig.php
+++ b/src/RemoteConfig.php
@@ -93,9 +93,9 @@ class RemoteConfig
             return self::DEFAULT_CONFIG;
         }
 
-        foreach ($config['settings'] as $cfg) {
-            if (isset($cfg["name"]) && $cfg["name"] == "errors") {
-                $errorConfig = $cfg;
+        foreach ($config['settings'] as $s) {
+            if (isset($s["name"]) && $s["name"] == "errors") {
+                $errorConfig = $s;
                 break;
             }
         };

--- a/src/TempCache.php
+++ b/src/TempCache.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Airbrake;
+
+class TempCache
+{
+    protected $file;
+    protected $ttl;
+
+    public function __construct($filename = 'airbrake_temp_cache.json', $ttl = 600)
+    {
+        $this->file = $this->getSystemTempDirectory() . "/" . $filename;
+        $this->ttl = $ttl;
+    }
+
+    public function canWrite()
+    {
+        return is_writeable(dirname($this->file));
+    }
+
+    public function expired()
+    {
+        if (!is_file($this->file)) {
+            return true;
+        }
+
+        $expiresAt = filemtime($this->file) + $this->ttl;
+        return time() > $expiresAt;
+    }
+
+    /**
+        Reads the temp cache file and returns the contents or false if reading
+        fails.
+    **/
+    public function read()
+    {
+        try {
+            return $this->readCacheFile();
+        } catch (\Exception $e) {
+            unset($e);
+            return false;
+        }
+    }
+
+    public function write($value)
+    {
+        try {
+            return $this->writeCacheFile($value);
+        } catch (\Exception $e) {
+            unset($e);
+            return false;
+        }
+    }
+
+    protected function readCacheFile()
+    {
+        $value = file_get_contents($this->file);
+
+        if ($value === false || $value == "") {
+            return false;
+        }
+
+        return unserialize($value);
+    }
+
+    /**
+       Writes or overwrites the temp cache file with $value.
+       Returns true or false depending on success.
+    **/
+    protected function writeCacheFile($value)
+    {
+        $success = file_put_contents($this->file, serialize($value));
+        return (bool) $success;
+    }
+
+    protected function getSystemTempDirectory()
+    {
+        return sys_get_temp_dir();
+    }
+}

--- a/tests/NotifierMock.php
+++ b/tests/NotifierMock.php
@@ -10,6 +10,7 @@ class NotifierMock extends Notifier
     public $url;
     public $notice;
     public $resp;
+    public $remoteConfigMock;
 
     public function __construct($opt)
     {
@@ -33,11 +34,19 @@ class NotifierMock extends Notifier
         return new FulfilledPromise($this->resp);
     }
 
-    protected function remoteErrorConfig()
+    protected function newRemoteConfig($projectId)
     {
-        return [
-            'host' => 'api.airbrake.io',
-            'enabled' => true
-        ];
+        if (isset($this->remoteConfigMock)) {
+            return $this->remoteConfigMock;
+        }
+
+        $remoteConfigMock = new RemoteConfigMock($projectId);
+        $remoteConfigMock->mockErrorConfig();
+        return $remoteConfigMock;
+    }
+
+    public function setupRemoteConfigMock()
+    {
+        $this->remoteConfigMock = $this->newRemoteConfig($this->opt['projectId']);
     }
 }

--- a/tests/NotifierMock.php
+++ b/tests/NotifierMock.php
@@ -32,4 +32,12 @@ class NotifierMock extends Notifier
         $this->notice = json_decode($data, true);
         return new FulfilledPromise($this->resp);
     }
+
+    protected function remoteErrorConfig()
+    {
+        return [
+            'host' => 'api.airbrake.io',
+            'enabled' => true
+        ];
+    }
 }

--- a/tests/NotifierTest.php
+++ b/tests/NotifierTest.php
@@ -2,8 +2,8 @@
 
 namespace Airbrake\Tests;
 
-// Update version across all tests in a single location.
-const AIRBRAKE_NOTIFIER_VERSION = '0.7.5';
+use Airbrake;
+const AIRBRAKE_NOTIFIER_VERSION = Airbrake\AIRBRAKE_NOTIFIER_VERSION;
 
 use PHPUnit_Framework_TestCase;
 

--- a/tests/NotifierTest.php
+++ b/tests/NotifierTest.php
@@ -129,6 +129,37 @@ class NotifierTest extends PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('revision', $notifier->notice['context']);
     }
 
+    public function testRemoteConfigOptionDefaut()
+    {
+        $notifier = new NotifierMock([
+            'projectId' => 42,
+            'projectKey' => 'api_key'
+        ]);
+        $notifier->setupRemoteConfigMock();
+        $notifier->remoteConfigMock->mockErrorConfig('remote.airbrake.io');
+        $notifier->notify(Troublemaker::newException());
+        $this->assertEquals(
+            $notifier->url,
+            "https://remote.airbrake.io/api/v3/projects/42/notices",
+            'The notice url is from the remote config'
+        );
+    }
+
+    public function testRemoteConfigOptionDisabled()
+    {
+        $notifier = new NotifierMock([
+            'projectId' => 42,
+            'projectKey' => 'api_key',
+            'remoteConfig' => false,
+        ]);
+        $notifier->notify(Troublemaker::newException());
+        $this->assertEquals(
+            $notifier->url,
+            "https://api.airbrake.io/api/v3/projects/42/notices",
+            'The notice url is not from the remote config'
+        );
+    }
+
     /** @dataProvider errorResponseProvider */
     public function testErrorResponse($notice, $expectedErrorMessage)
     {

--- a/tests/NotifierTest.php
+++ b/tests/NotifierTest.php
@@ -2,6 +2,9 @@
 
 namespace Airbrake\Tests;
 
+// Update version across all tests in a single location.
+const AIRBRAKE_NOTIFIER_VERSION = '0.7.5';
+
 use PHPUnit_Framework_TestCase;
 
 class NotifierTest extends PHPUnit_Framework_TestCase

--- a/tests/RemoteConfigMock.php
+++ b/tests/RemoteConfigMock.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Airbrake\Tests;
+
+use Airbrake\RemoteConfig;
+
+class RemoteConfigMock extends RemoteConfig
+{
+    public $tempCache;
+
+    public function __construct($projectId)
+    {
+        parent::__construct($projectId);
+        $this->tempCache = new TempCacheMock(
+            $this->tempCacheFilename,
+            $this->tempCacheTTL
+        );
+    }
+
+    public function setMockClient($mockClient)
+    {
+        $this->httpClient = $mockClient;
+    }
+}

--- a/tests/RemoteConfigMock.php
+++ b/tests/RemoteConfigMock.php
@@ -21,4 +21,23 @@ class RemoteConfigMock extends RemoteConfig
     {
         $this->httpClient = $mockClient;
     }
+
+    public function errorConfig()
+    {
+        if (isset($this->mockErrorConfig)) {
+            return $this->mockErrorConfig;
+        }
+
+        return parent::errorConfig();
+    }
+
+    // This is a helper function to mock the return value of the
+    // errorConfig method.
+    public function mockErrorConfig($host = "api.airbrake.io", $enabled = true)
+    {
+        $this->mockErrorConfig = [
+            "host" => $host,
+            "enabled" => $enabled
+        ];
+    }
 }

--- a/tests/RemoteConfigTest.php
+++ b/tests/RemoteConfigTest.php
@@ -1,0 +1,244 @@
+<?php
+
+namespace Airbrake\Tests;
+
+use PHPUnit\Framework\TestCase;
+use GuzzleHttp\Client;
+
+class RemoteConfigTest extends TestCase
+{
+    private $projectId = 555;
+    private $remoteConfigURL = 'https://notifier-configs.airbrake.io' .
+        '/2020-06-18/config/555/config.json';
+    private $remoteConfig;
+    private $remoteErrorConfig;
+    private $responseBody;
+    private $defaultConfig = [
+        "host" => 'api.airbrake.io',
+        "enabled" => true
+    ];
+    private $notifierInfo = [
+        'notifier_name' => 'phpbrake',
+        'notifier_version' => AIRBRAKE_NOTIFIER_VERSION,
+        'os' => PHP_OS,
+        'language' => "PHP" . PHP_VERSION
+    ];
+
+    protected function setUp()
+    {
+        $this->remoteConfig = new RemoteConfigMock($this->projectId);
+        $this->remoteErrorConfig = [
+            "name" => "errors",
+            "endpoint" => "remote-config.airbrake.io",
+            "enabled" => true
+        ];
+        $this->responseBody = [
+            "settings" => [$this->remoteErrorConfig]
+        ];
+    }
+
+    public function testWithValidRemoteConfig()
+    {
+        $this->mockRemoteResponse(200, $this->responseBody);
+
+        $this->assertSame(
+            $this->remoteConfig->errorConfig(),
+            [
+                "host" => 'remote-config.airbrake.io',
+                "enabled" => true
+            ]
+        );
+    }
+
+    public function testWithErrorsDisabled()
+    {
+        $this->remoteErrorConfig['enabled'] = false;
+        $this->responseBody['settings'] = [ $this->remoteErrorConfig ];
+        $this->mockRemoteResponse(200, $this->responseBody);
+
+        $this->assertSame(
+            $this->remoteConfig->errorConfig(),
+            [
+                "host" => 'remote-config.airbrake.io',
+                "enabled" => false
+            ]
+        );
+    }
+
+    public function testWithNoKnownHost()
+    {
+        $this->remoteErrorConfig['endpoint'] = null;
+        $this->responseBody['settings'] = [ $this->remoteErrorConfig ];
+        $this->mockRemoteResponse(200, $this->responseBody);
+
+        $this->assertSame(
+            $this->remoteConfig->errorConfig(),
+            [
+                "host" => $this->defaultConfig['host'],
+                "enabled" => true
+            ]
+        );
+    }
+
+    public function testWithMissingHostConfig()
+    {
+        $this->responseBody['settings'] = [
+            [
+                "name" => 'error',
+                "enabled" => false
+            ]
+        ];
+        $this->mockRemoteResponse(200, $this->responseBody);
+
+        $this->returnsTheDefaultConfig();
+    }
+
+    public function testWithoutErrorConfig()
+    {
+        $this->responseBody['settings'] = [
+            [
+                "name" => 'event',
+                "enabled" => true
+            ]
+        ];
+        $this->mockRemoteResponse(200, $this->responseBody);
+
+        $this->returnsTheDefaultConfig();
+    }
+
+    public function testWithAnUnexpectedStatusCode()
+    {
+        $this->mockRemoteResponse(403, null);
+
+        $this->returnsTheDefaultConfig();
+    }
+
+    public function testWithAnEmptyResponse()
+    {
+        $this->mockRemoteResponse(200, []);
+
+        $this->returnsTheDefaultConfig();
+    }
+
+    public function testWhenTheRequestRaisesAnException()
+    {
+        $mockClient = $this
+            ->getMockBuilder(GuzzleHttp\Client::class)
+            ->setMethods(['request'])
+            ->getMock();
+        $mockClient
+            ->method('request')
+            ->will($this->throwException(new \Exception));
+        $this->remoteConfig->setMockClient($mockClient);
+
+        $this->returnsTheDefaultConfig();
+    }
+
+    public function testConfiguredWithExpectedCacheSettings()
+    {
+        $this->assertSame(
+            'airbrake_cached_remote_config.json',
+            $this->remoteConfig->tempCache->filename
+        );
+        $this->assertSame(600, $this->remoteConfig->tempCache->ttl);
+    }
+
+    public function testCannotWriteCache()
+    {
+        $this->remoteConfig->tempCache->mockCanWrite = false;
+
+        $this->remoteConfig->errorConfig();
+
+        $didNotReadFromCache = !$this->remoteConfig->tempCache->wasRead;
+        $didNotWriteToCache = !$this->remoteConfig->tempCache->wasWritten;
+        $this->assertTrue($didNotReadFromCache);
+        $this->assertTrue($didNotWriteToCache);
+        $this->returnsTheDefaultConfig();
+    }
+
+    public function testReadsFromCacheWhenNotExpired()
+    {
+        $this->remoteConfig->tempCache->mockCanWrite = true;
+        // write config to the cache
+        $this->remoteConfig->errorConfig();
+
+        $this->remoteConfig->tempCache->mockExpired = false;
+        // read config from cache
+        $config = $this->remoteConfig->errorConfig();
+
+        $this->assertTrue($this->remoteConfig->tempCache->wasRead);
+        $this->assertSame(
+            $this->remoteConfig->tempCache->lastReadValue,
+            $config
+        );
+    }
+
+    public function testWritesToCacheWhenExpired()
+    {
+        $this->remoteConfig->tempCache->mockCanWrite = true;
+        $this->remoteConfig->tempCache->mockExpired = true;
+
+        $config = $this->remoteConfig->errorConfig();
+
+        $this->assertTrue($this->remoteConfig->tempCache->wasWritten);
+        $this->assertSame(
+            $this->remoteConfig->tempCache->lastWrittenValue,
+            $config
+        );
+    }
+    // RemoteConfigTest helpers for mocking and asserting when the default
+    // config is returned.
+
+    protected function returnsTheDefaultConfig()
+    {
+        $this->assertSame(
+            $this->remoteConfig->errorConfig(),
+            $this->defaultConfig
+        );
+    }
+
+    private function mockRemoteResponse($statusCode, $body)
+    {
+        $mockResponse = $this->createMockResponse($statusCode, $body);
+        $mockClient = $this->createMockClient($mockResponse);
+        $this->remoteConfig->setMockClient($mockClient);
+    }
+
+    private function createMockClient($mockResponse)
+    {
+        $mockClient = $this
+            ->getMockBuilder(GuzzleHttp\Client::class)
+            ->setMethods(['request'])
+            ->getMock();
+        $mockClient
+            ->expects($this->once())
+            ->method('request')
+            ->with(
+                'GET',
+                $this->remoteConfigURL,
+                ['query' => $this->notifierInfo]
+            )
+            ->willReturn($mockResponse);
+        return $mockClient;
+    }
+
+    private function createMockResponse($statusCode, $body)
+    {
+        $mockResponse = $this
+            ->getMockBuilder(GuzzleHttp\Psr7\Response::class)
+            ->setMethods(['getStatusCode', 'getBody'])
+            ->getMock();
+        $mockResponse
+            ->expects($this->once())
+            ->method('getStatusCode')
+            ->willReturn($statusCode);
+        if (isset($body)) {
+            $mockResponse
+                ->expects($this->once())
+                ->method('getBody')
+                ->willReturn(json_encode($body));
+        }
+
+        return $mockResponse;
+    }
+}

--- a/tests/RemoteConfigTest.php
+++ b/tests/RemoteConfigTest.php
@@ -13,10 +13,6 @@ class RemoteConfigTest extends TestCase
     private $remoteConfig;
     private $remoteErrorConfig;
     private $responseBody;
-    private $defaultConfig = [
-        "host" => 'api.airbrake.io',
-        "enabled" => true
-    ];
     private $notifierInfo = [
         'notifier_name' => 'phpbrake',
         'notifier_version' => AIRBRAKE_NOTIFIER_VERSION,
@@ -74,7 +70,7 @@ class RemoteConfigTest extends TestCase
         $this->assertSame(
             $this->remoteConfig->errorConfig(),
             [
-                "host" => $this->defaultConfig['host'],
+                "host" => $this->remoteConfig::DEFAULT_CONFIG['host'],
                 "enabled" => true
             ]
         );
@@ -193,7 +189,7 @@ class RemoteConfigTest extends TestCase
     {
         $this->assertSame(
             $this->remoteConfig->errorConfig(),
-            $this->defaultConfig
+            $this->remoteConfig::DEFAULT_CONFIG
         );
     }
 

--- a/tests/TempCacheMock.php
+++ b/tests/TempCacheMock.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Airbrake\Tests;
+
+use Airbrake\TempCache;
+use org\bovigo\vfs\vfsStream;
+
+class TempCacheMock extends TempCache
+{
+    public $mockTempDir;
+    public $filename;
+    public $file;
+    public $ttl;
+
+    // Helper vars to inspect the last read or write calls.
+    public $wasRead = false;
+    public $lastReadValue = null;
+    public $wasWritten = false;
+    public $lastWrittenValue = null;
+
+    // If unset, real canWrite() behavior is used.
+    // If set to true, can write to cache.
+    // If set to false, can't write to cache.
+    public $mockCanWrite;
+
+    // If unset, real expired() behavior is used.
+    // If set to true, the cache acts expired.
+    // If set to false, the cache acts fresh.
+    public $mockExpired;
+
+    // Set to true when you want to throw exceptions for reads or writes.
+    public $throwReadException = false;
+    public $throwWriteException = false;
+
+    public function __construct($filename = 'airbrake_temp_cache.json', $ttl = 600)
+    {
+        $this->filename = $filename;
+        $this->ttl = $ttl;
+        $this->mockTempDir = vfsStream::setup($this->getSystemTempDirectory());
+        $this->file = $this->mockTempDir->url() . "/" . $this->filename;
+    }
+
+    public function mockAvailableTempDir()
+    {
+        $this->mockTempDir->chmod(0777);
+    }
+
+    public function mockUnavailableTempDir()
+    {
+        $this->mockTempDir->chmod(0000);
+    }
+
+    public function canWrite()
+    {
+        if (isset($this->mockCanWrite)) {
+            return $this->mockCanWrite;
+        }
+
+        return parent::canWrite();
+    }
+
+    public function expired()
+    {
+        if (isset($this->mockExpired)) {
+            return $this->mockExpired;
+        }
+
+        return parent::expired();
+    }
+
+    protected function readCacheFile()
+    {
+        if ($this->throwReadException) {
+            throw new \Exception('read fails');
+        }
+
+        $value = parent::readCacheFile();
+        $this->wasRead = true;
+        $this->lastReadValue = $value;
+
+        return $value;
+    }
+
+    protected function writeCacheFile($value)
+    {
+        if ($this->throwWriteException) {
+            throw new \Exception('Write fails');
+        }
+
+        $parentWrite = parent::writeCacheFile($value);
+        $this->wasWritten = true;
+        $this->lastWrittenValue = $value;
+
+        return $parentWrite;
+    }
+
+    protected function getSystemTempDirectory()
+    {
+        return 'test_temp_dir';
+    }
+}

--- a/tests/TempCacheTest.php
+++ b/tests/TempCacheTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Airbrake\Tests;
+
+use Airbrake\TempCache;
+use PHPUnit\Framework\TestCase;
+
+class TempCacheTest extends TestCase
+{
+    private $cachedValue = ['key' => 'value'];
+
+    protected function setUp()
+    {
+        $this->tempCache = new TempCacheMock();
+    }
+
+    public function testSuccessfulWrite()
+    {
+        $this->assertTrue($this->tempCache->write($this->cachedValue));
+    }
+
+    public function testWriteWithErrors()
+    {
+        $this->tempCache->throwWriteException = true;
+        $this->assertSame(
+            $this->tempCache->write($this->cachedValue),
+            false
+        );
+    }
+
+    public function testReadWithErrors()
+    {
+        $this->tempCache->throwReadException = true;
+        $this->tempCache->write($this->cachedValue);
+
+        $this->assertSame(
+            $this->tempCache->read(),
+            false
+        );
+    }
+
+    public function testCanWriteWithAvailableTempDir()
+    {
+        $this->tempCache->mockAvailableTempDir();
+        $this->assertTrue($this->tempCache->canWrite());
+    }
+
+    public function testCanWriteWithUnavailableTempDir()
+    {
+        $this->tempCache->mockUnavailableTempDir();
+        $this->assertSame(
+            $this->tempCache->canWrite(),
+            false
+        );
+    }
+}


### PR DESCRIPTION
Adds support for fetching the remote notifier config when possible. The remote config feature creates a base for more flexible PHPBrake configuration and features at runtime. The remote config is cached for 10 minutes in a temp file in the system's temp directory. If fetching or caching fails or is unavailable for any reason, the default settings are used. 

A few notes on `Airbrake\Notifier` initialization options and the remote config:
- This Adds a new `remoteConfig` option to the initialization of the `Airbrake\Notifer` that defaults to `true`. If the `Airbrake\Notifier` is initialized with the `remoteConfig` set to `false`, the config will not be fetched from the remote and the default endpoint will be used.
- If the `host` option is specified with `Airbrake\Notifier` initialization that will take precedence over the host fetched from the remote config.