### PR TITLE
ignore http exceptions

### DIFF
--- a/src/Notifier.php
+++ b/src/Notifier.php
@@ -319,7 +319,13 @@ class Notifier
         }
 
         $req = $this->newHttpRequest($notice);
-        $resp = $this->sendRequest($req);
+        try {
+            $resp = $this->sendRequest($req);
+        } catch (\Exception $e) {
+            // Not all exceptions are handled when 'http_errors' => false. Timeouts for example. We ignore these in general.
+            $notice['error'] = 'http send failed: ' . $e->getMessage();
+            return $notice;
+        }
         return $this->processHttpResponse($notice, $resp);
     }
 


### PR DESCRIPTION
http errors are ignored but http timeouts trigger curlexception and thus fatal error in php. in cases the code would run after the airbrake error this is bad.

I couldn't find guzzle settings to ignore these in general (404, 500 can be ignored and they are)